### PR TITLE
depend explicitly on ipaddr.unix

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true : bin_annot, safe_string, warn(-40), package(bytes), package(ipaddr), package(lwt)
+true : bin_annot, safe_string, warn(-40), package(bytes), package(ipaddr), package(ipaddr.unix), package(lwt)
 
 <src> : include
 <test> : include


### PR DESCRIPTION
This is needed for the Ipaddr_unix module, which will be built
separately in an upcoming Ipaddr release (due to switching to
jbuilder). This change is backwards compatible with existing ipaddr
releases as well.